### PR TITLE
Parse dsc/envisalink armed mode

### DIFF
--- a/Alarm/alarminterface/dsc_eventParser.js
+++ b/Alarm/alarminterface/dsc_eventParser.js
@@ -54,7 +54,7 @@ function parsePartitionArmed(cmd,cmdFullStr) {
     if(statusBit == '1' || statusBit == '3')
         msg.hsmstate = 'armedHome';
     else
-        msg.hsmstate = 'armedStay';
+        msg.hsmstate = 'armedAway';
     return msg;
 }
 

--- a/Alarm/alarminterface/dsc_eventParser.js
+++ b/Alarm/alarminterface/dsc_eventParser.js
@@ -51,7 +51,7 @@ function parseCodeRequired(cmd,cmdFullStr) {
 function parsePartitionArmed(cmd,cmdFullStr) {
     let msg = command_map[cmd];
     let statusBit = cmdFullStr[4];
-    if(statusBit == '1' || statusBit == '3') {
+    if(statusBit === '1' || statusBit === '3') {
         msg.hsmstate = 'armedHome';
     }
     else {

--- a/Alarm/alarminterface/dsc_eventParser.js
+++ b/Alarm/alarminterface/dsc_eventParser.js
@@ -51,10 +51,12 @@ function parseCodeRequired(cmd,cmdFullStr) {
 function parsePartitionArmed(cmd,cmdFullStr) {
     let msg = command_map[cmd];
     let statusBit = cmdFullStr[4];
-    if(statusBit == '1' || statusBit == '3')
+    if(statusBit == '1' || statusBit == '3') {
         msg.hsmstate = 'armedHome';
-    else
+    }
+    else {
         msg.hsmstate = 'armedAway';
+    }
     return msg;
 }
 

--- a/Alarm/alarminterface/dsc_eventParser.js
+++ b/Alarm/alarminterface/dsc_eventParser.js
@@ -15,6 +15,7 @@ exports.dsc_eventParser = dsc_eventParser
  * @parseZoneChange - parse zones update Open and Close.
  * @parseCodeRequired - parse when DSC-IT100 requires to enter the code.
  * @parseChimeToggle - parse Chime ON/OFF
+ * @parsePartitionArmed - parse the 652 partition armed message. will also read the home/away state
  *
  * @param {String} cmd - The received DSC-IT100 command. Only the first 3 numbers.
  * @param {String} cmdFullStr - The entire code number from DSC-IT100.
@@ -45,6 +46,14 @@ function parseCodeRequired(cmd,cmdFullStr) {
     let alarmCodeRequired = command_map[cmd];
     return alarmCodeRequired;
     //alarmSendCode()
+}
+
+function parsePartitionArmed(cmd,cmdFullStr) {
+    let msg = command_map[cmd];
+    let statusBit = cmdFullStr[4];
+    if(statusBit == '1' || statusBit == '3')
+        msg.hsmstate = 'armedHome';
+    return msg;
 }
 
 function parseChimeToggle(cmd,cmdFullStr) {
@@ -172,7 +181,7 @@ var command_map = {
         'code': '652',
         'hsmstate':'armedAway',
         'type': 'partition',
-        'handler': parseGenericReceivedData
+        'handler': parsePartitionArmed
     },
     '654': {
         'name': 'Partition in Alarm',
@@ -401,3 +410,4 @@ var command_map = {
         'handler': parseChimeToggle
     }
 };
+

--- a/Alarm/alarminterface/dsc_eventParser.js
+++ b/Alarm/alarminterface/dsc_eventParser.js
@@ -53,6 +53,8 @@ function parsePartitionArmed(cmd,cmdFullStr) {
     let statusBit = cmdFullStr[4];
     if(statusBit == '1' || statusBit == '3')
         msg.hsmstate = 'armedHome';
+    else
+        msg.hsmstate = 'armedStay';
     return msg;
 }
 


### PR DESCRIPTION
DSC/Envisalink sends the home/away status in the 652 `Partitioned Armed` event.   But this value is not parsed and the mode is hardcoded as away.  

This pr parses this value and sends it to the front end.